### PR TITLE
fix(mobile): adjust carousel margins for 15/70/15 peek effect and hidde sidebar on tablets

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -122,15 +122,15 @@
     scroll-snap-align: center;
     scroll-snap-stop: always;
     
-    /* Add horizontal margin to create the 15% "peek" gutters
-       (15% of viewport on each side) */
-    margin: 0 calc(7.5vw); /* 7.5 + 70 + 7.5 = 85 → but snap centers properly */
+    /* Small horizontal margin ensures adjacent columns are visible
+       in the 15vw space left and right of the centered column */
+    margin: 0 2vw;
     
     /* Raise z-index slightly for active column */
     position: relative;
   }
   
-  /* First and last columns need only one-side margin for true 15% peek */
+  /* First and last columns need extra margin to be able to snap to center */
   .kp-kanban-col:first-child {
     margin-left: 15vw;
     scroll-margin-left: 15vw;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -158,8 +158,8 @@ a:hover {
   padding-top: env(safe-area-inset-top);
 }
 
-/* Mobile: sidebar hidden off-canvas by default */
-@media (max-width: 767px) {
+/* Mobile & Tablet Portrait: sidebar hidden off-canvas by default */
+@media (max-width: 1023px) {
   .kp-sidebar {
     transform: translateX(-100%);
     width: min(280px, 80vw);
@@ -268,7 +268,7 @@ a:hover {
   transition: margin-left 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-@media (max-width: 767px) {
+@media (max-width: 1023px) {
   .kp-main-wrapper {
     margin-left: 0;
   }
@@ -333,7 +333,7 @@ a:hover {
   background: var(--kp-surface-hover);
 }
 
-@media (max-width: 767px) {
+@media (max-width: 1023px) {
   .kp-menu-toggle {
     display: flex;
   }


### PR DESCRIPTION
## Efecto "Peek" 15/70/15 Real ##
El problema era que el margen entre columnas era exactamente del 15%, por lo que la siguiente columna quedaba empujada justo fuera del borde de la pantalla. Reduje la separación interna (a 2vw), permitiendo que el 11% de la columna anterior y la siguiente "asomen" hacia el centro, dándote visibilidad para saber hacia dónde arrastrar.

## Sidebar oculto en Vertical/Tablets ##
Modifiqué el breakpoint en main.css. Ahora el panel lateral se oculta (off-canvas detrás del menú hamburguesa) en cualquier pantalla menor a 1024px (lo que cubre móviles y tablets en formato vertical). Así el tablero se expande al 100% del ancho para aprovechar cada pixel posible